### PR TITLE
Remove simplified OpenStreetMapData

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && wget --quiet http://data.openstreetmapdata.com/water-polygons-split-3857.zip \
     && unzip -oj water-polygons-split-3857.zip -d $IMPORT_DATA_DIR \
     && rm water-polygons-split-3857.zip \
-    && wget --quiet http://data.openstreetmapdata.com/simplified-water-polygons-complete-3857.zip \
-    && unzip -oj simplified-water-polygons-complete-3857.zip -d $IMPORT_DATA_DIR \
-    && rm simplified-water-polygons-complete-3857.zip \
     && apt-get -y --auto-remove purge \
       wget \
       unzip \

--- a/import-water.sh
+++ b/import-water.sh
@@ -4,7 +4,6 @@ set -o pipefail
 set -o nounset
 
 readonly WATER_POLYGONS_FILE="$IMPORT_DATA_DIR/water_polygons.shp"
-readonly SIMPLIFIED_WATER_POLYGONS_FILE="$IMPORT_DATA_DIR/simplified_water_polygons.shp"
 
 function exec_psql() {
     PGPASSWORD=$POSTGRES_PASSWORD psql --host="$POSTGRES_HOST" --port="$POSTGRES_PORT" --dbname="$POSTGRES_DB" --username="$POSTGRES_USER"


### PR DESCRIPTION
 `simplified-water-polygons-complete-3857` are not used since https://github.com/openmaptiles/import-water/commit/07051cd1fa97f1fac1a60c19035b34f33421808e.