### PR TITLE
Update URL openstreetmapdata

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,14 +6,16 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       wget \
       unzip \
       sqlite3 \
+      ca-certificates \
     && mkdir -p $IMPORT_DATA_DIR \
-    && wget --quiet http://data.openstreetmapdata.com/water-polygons-split-3857.zip \
+    && wget --quiet http://osmdata.openstreetmap.de/download/water-polygons-split-3857.zip \
     && unzip -oj water-polygons-split-3857.zip -d $IMPORT_DATA_DIR \
     && rm water-polygons-split-3857.zip \
     && apt-get -y --auto-remove purge \
       wget \
       unzip \
       sqlite3 \
+      ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /usr/src/app

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Import Water from OpenStreetMapData into PostGIS
 [![Docker Automated build](https://img.shields.io/docker/automated/openmaptiles/import-osm.svg?maxAge=2592000)]() [![](https://images.microbadger.com/badges/image/openmaptiles/import-osm.svg)](https://microbadger.com/images/openmaptiles/import-osm)
 
-This is a Docker image to import and simplify water polygons from [OpenStreetMapData](http://openstreetmapdata.com/) using *shp2pgsql* into a PostGIS database.
+This is a Docker image to import and simplify water polygons from [OpenStreetMapData](http://osmdata.openstreetmap.de/) using *shp2pgsql* into a PostGIS database.
 The Shapefiles are already baked into the container to make distribution and execution easier.
 
 ## Usage
@@ -18,4 +18,4 @@ docker run --rm \
     openmaptiles/import-water
 ```
 ## Version of OpenStreetMapData
-**2019-02-21**
+**2019-05-13**


### PR DESCRIPTION
- https://github.com/openmaptiles/openmaptiles/issues/591

New dataset is different - it has been changed from irregular grid to regullar.
before:
![Screenshot from 2019-05-16 11-48-49](https://user-images.githubusercontent.com/8367628/57844887-2b4f5380-77d1-11e9-8fde-a259d065a521.png)
after:
![Screenshot from 2019-05-16 11-48-21](https://user-images.githubusercontent.com/8367628/57844912-35715200-77d1-11e9-86dc-960df6eee6a8.png)

Number of polygons was reduced, but a lot of them is more complex, so it takes longer to upload them to DB and create views for water layer in openmaptiles project. There is no problem with performance in final vector tiles.

Positive change is that there should be no problems on tile edges:
before - after:
![tile_problems_compare](https://user-images.githubusercontent.com/8367628/57845396-3951a400-77d2-11e9-8966-ae282d334247.png)
