### PR TITLE
Simplify Dockerfile - base it on tools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,11 @@
-FROM openmaptiles/postgis:2.9
+FROM openmaptiles/openmaptiles-tools:0.12.0
 ENV IMPORT_DATA_DIR=/import \
     NATURAL_EARTH_DB=/import/natural_earth_vector.sqlite
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-      wget \
-      unzip \
-      sqlite3 \
-      ca-certificates \
-    && mkdir -p $IMPORT_DATA_DIR \
+RUN mkdir -p $IMPORT_DATA_DIR \
     && wget --quiet http://osmdata.openstreetmap.de/download/water-polygons-split-3857.zip \
     && unzip -oj water-polygons-split-3857.zip -d $IMPORT_DATA_DIR \
-    && rm water-polygons-split-3857.zip \
-    && apt-get -y --auto-remove purge \
-      wget \
-      unzip \
-      sqlite3 \
-      ca-certificates \
-    && rm -rf /var/lib/apt/lists/*
+    && rm water-polygons-split-3857.zip
 
 WORKDIR /usr/src/app
 COPY . /usr/src/app


### PR DESCRIPTION
openmaptiles-tools already includes all the needed tools,
so just use it as the base, adding the water to it.

P.S. My next step will be to migrate it to tools itself, but still keep it as a separate docke rimage